### PR TITLE
Fix exam submission and file display

### DIFF
--- a/src/controllers/examController.js
+++ b/src/controllers/examController.js
@@ -1304,7 +1304,7 @@ exports.submitProjectExam = async (req, res) => {
             currentAttempt.submittedAt = new Date();
             await currentAttempt.save();
 
-            // Create initial result record with PENDING status (will be updated when graded)
+            // Create initial result record with UNDER_REVIEW status (will be updated when graded)
             await Result.create({
                 examId: exam._id,
                 studentId: req.user._id,
@@ -1312,7 +1312,7 @@ exports.submitProjectExam = async (req, res) => {
                 totalMarks: exam.projectTotalMarks || exam.totalMarks,
                 obtainedMarks: 0, // Will be updated by teacher
                 percentage: 0, // Will be updated by teacher
-                status: 'PENDING', // Changed from FAIL to PENDING for projects
+                status: 'UNDER_REVIEW', // Projects start as under review, not with marks
                 analytics: {
                     timeSpent: Math.floor((new Date() - currentAttempt.startTime) / 1000),
                     attemptsCount: nextAttemptNumber,

--- a/src/views/exam/result-details.ejs
+++ b/src/views/exam/result-details.ejs
@@ -25,10 +25,17 @@
             <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
                 <h2 class="mb-0"><%= exam.title %> - النتائج</h2>
                 <div>
-                    <span class="badge bg-light text-dark me-2">الدرجة: <%= result.grade %></span>
-                    <span class="badge bg-light text-dark">
-                        الدرجة: <%= result.obtainedMarks %>/<%= result.totalMarks %> (<%= result.percentage.toFixed(2) %>%)
-                    </span>
+                    <% if (result.status === 'UNDER_REVIEW' || result.status === 'PENDING') { %>
+                        <span class="badge bg-warning text-dark me-2">قيد المراجعة</span>
+                        <span class="badge bg-light text-dark">
+                            لم يتم التقييم بعد
+                        </span>
+                    <% } else { %>
+                        <span class="badge bg-light text-dark me-2">الدرجة: <%= result.grade %></span>
+                        <span class="badge bg-light text-dark">
+                            الدرجة: <%= result.obtainedMarks %>/<%= result.totalMarks %> (<%= result.percentage.toFixed(2) %>%)
+                        </span>
+                    <% } %>
                 </div>
             </div>
         
@@ -40,9 +47,15 @@
                     <div class="col-md-6">
                         <p><strong>الاسم:</strong> <%= result.studentId.firstName %> <%= result.studentId.lastName %></p>
                         <p><strong>الحالة:</strong> 
-                            <span class="badge bg-<%= result.status === 'PASS' ? 'success' : 'danger' %>">
-                                <%= result.status %>
-                            </span>
+                            <% if (result.status === 'UNDER_REVIEW' || result.status === 'PENDING') { %>
+                                <span class="badge bg-warning text-dark">
+                                    قيد المراجعة
+                                </span>
+                            <% } else { %>
+                                <span class="badge bg-<%= result.status === 'PASS' ? 'success' : 'danger' %>">
+                                    <%= result.status === 'PASS' ? 'نجح' : result.status === 'FAIL' ? 'فشل' : result.status %>
+                                </span>
+                            <% } %>
                         </p>
                     </div>
                     <div class="col-md-6">
@@ -60,9 +73,13 @@
                         <div class="card bg-light">
                             <div class="card-body text-center">
                                 <h5>معدل الدرجات</h5>
-                                <h3 class="text-<%= result.percentage >= 60 ? 'success' : 'danger' %>">
-                                    <%= result.analytics.accuracyRate.toFixed(1) %>%
-                                </h3>
+                                <% if (result.status === 'UNDER_REVIEW' || result.status === 'PENDING') { %>
+                                    <h3 class="text-warning">قيد التقييم</h3>
+                                <% } else { %>
+                                    <h3 class="text-<%= result.percentage >= 60 ? 'success' : 'danger' %>">
+                                        <%= result.analytics.accuracyRate.toFixed(1) %>%
+                                    </h3>
+                                <% } %>
                             </div>
                         </div>
                     </div>
@@ -128,31 +145,78 @@
                     <div class="card">
                         <div class="card-body">
                             <% if (submission.projectSubmission) { %>
-                                <!-- Project File -->
+                                <!-- Project Files -->
                                 <div class="mb-4">
-                                    <h5>ملف التقديم</h5>
-                                    <p>
-                                        <strong>اسم الملف:</strong> <%= submission.projectSubmission.fileName %><br>
-                                        <strong>تاريخ التقديم:</strong> <%= new Date(submission.projectSubmission.submittedAt).toLocaleString() %><br>
-                                        <% if (submission.projectSubmission.fileUrl) { %>
-                                            <a href="<%= submission.projectSubmission.fileUrl %>" class="btn btn-sm btn-primary mt-2" target="_blank">
-                                                <i class="fas fa-download"></i> تحميل ملف المشروع
-                                            </a>
-                                        <% } %>
-                                    </p>
+                                    <h5>ملفات التقديم</h5>
+                                    <p><strong>تاريخ التقديم:</strong> <%= new Date(submission.projectSubmission.submittedAt).toLocaleString() %></p>
+                                    
+                                    <% if (submission.projectSubmission.files && submission.projectSubmission.files.length > 0) { %>
+                                        <!-- Multiple files (new format) -->
+                                        <p><strong>عدد الملفات:</strong> <%= submission.projectSubmission.files.length %></p>
+                                        <div class="row">
+                                            <% submission.projectSubmission.files.forEach((file, index) => { %>
+                                                <div class="col-md-6 mb-3">
+                                                    <div class="card border-secondary">
+                                                        <div class="card-body p-3">
+                                                            <h6 class="card-title mb-2">
+                                                                <i class="fas fa-file"></i> ملف <%= index + 1 %>
+                                                            </h6>
+                                                            <p class="card-text small mb-2">
+                                                                <strong>اسم الملف:</strong> <%= file.fileName %><br>
+                                                                <strong>الحجم:</strong> <%= (file.fileSize / (1024 * 1024)).toFixed(2) %> MB<br>
+                                                                <strong>النوع:</strong> <%= file.fileType %><br>
+                                                                <strong>تاريخ الرفع:</strong> <%= new Date(file.uploadedAt).toLocaleString() %>
+                                                            </p>
+                                                            <a href="<%= file.fileUrl %>" class="btn btn-sm btn-primary" target="_blank">
+                                                                <i class="fas fa-download"></i> تحميل
+                                                            </a>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            <% }); %>
+                                        </div>
+                                    <% } else if (submission.projectSubmission.fileUrl) { %>
+                                        <!-- Single file (legacy format) -->
+                                        <div class="card border-secondary">
+                                            <div class="card-body">
+                                                <p>
+                                                    <strong>اسم الملف:</strong> <%= submission.projectSubmission.fileName %><br>
+                                                    <% if (submission.projectSubmission.fileSize) { %>
+                                                        <strong>الحجم:</strong> <%= (submission.projectSubmission.fileSize / (1024 * 1024)).toFixed(2) %> MB<br>
+                                                    <% } %>
+                                                    <% if (submission.projectSubmission.fileType) { %>
+                                                        <strong>النوع:</strong> <%= submission.projectSubmission.fileType %><br>
+                                                    <% } %>
+                                                </p>
+                                                <a href="<%= submission.projectSubmission.fileUrl %>" class="btn btn-sm btn-primary mt-2" target="_blank">
+                                                    <i class="fas fa-download"></i> تحميل ملف المشروع
+                                                </a>
+                                            </div>
+                                        </div>
+                                    <% } else { %>
+                                        <div class="alert alert-warning">
+                                            <i class="fas fa-exclamation-triangle"></i> لا توجد ملفات مقدمة.
+                                        </div>
+                                    <% } %>
                                 </div>
 
                                 <!-- Teacher's Feedback -->
                                 <div class="mb-4">
                                     <h5>تعليق المدرس</h5>
-                                    <div class="card bg-light">
-                                        <div class="card-body">
-                                            <p class="mb-0"><%= submission.projectSubmission.feedback.text %></p>
-                                            <small class="text-muted mt-2 d-block">
-                                                تعليق معطى في: <%= new Date(submission.projectSubmission.feedback.givenAt).toLocaleString() %>
-                                            </small>
+                                    <% if (submission.projectSubmission.feedback && submission.projectSubmission.feedback.text) { %>
+                                        <div class="card bg-light">
+                                            <div class="card-body">
+                                                <p class="mb-0"><%= submission.projectSubmission.feedback.text %></p>
+                                                <small class="text-muted mt-2 d-block">
+                                                    تعليق معطى في: <%= new Date(submission.projectSubmission.feedback.givenAt).toLocaleString() %>
+                                                </small>
+                                            </div>
                                         </div>
-                                    </div>
+                                    <% } else { %>
+                                        <div class="alert alert-info">
+                                            <i class="fas fa-info-circle"></i> لم يتم تقديم تعليق من المدرس بعد.
+                                        </div>
+                                    <% } %>
                                 </div>
                             <% } else { %>
                                 <div class="alert alert-info">

--- a/src/views/exam/results.ejs
+++ b/src/views/exam/results.ejs
@@ -183,12 +183,14 @@
                                                             <% } %>
                                                         </td>
                                                         <td>
-                                                            <% if (true) { %>
-                                                                <span class="badge bg-<%= result.status === 'PASS' ? 'success' : 'danger' %>">
-                                                                    <%= result.status %>
+                                                            <% if (result.status === 'UNDER_REVIEW' || result.status === 'PENDING') { %>
+                                                                <span class="badge bg-warning text-dark">
+                                                                    قيد المراجعة
                                                                 </span>
                                                             <% } else { %>
-                                                                <span class="badge bg-secondary">قيد الإنتظار</span>
+                                                                <span class="badge bg-<%= result.status === 'PASS' ? 'success' : 'danger' %>">
+                                                                    <%= result.status === 'PASS' ? 'نجح' : result.status === 'FAIL' ? 'فشل' : result.status %>
+                                                                </span>
                                                             <% } %>
                                                         </td>
                                                         <td>
@@ -274,12 +276,14 @@
                                                             <% } %>
                                                         </td>
                                                         <td>
-                                                            <% if (true) { %>
-                                                                <span class="badge bg-<%= result.status === 'PASS' ? 'success' : 'danger' %>">
-                                                                    <%= result.status %>
+                                                            <% if (result.status === 'UNDER_REVIEW' || result.status === 'PENDING') { %>
+                                                                <span class="badge bg-warning text-dark">
+                                                                    قيد المراجعة
                                                                 </span>
                                                             <% } else { %>
-                                                                <span class="badge bg-secondary">قيد الإنتظار</span>
+                                                                <span class="badge bg-<%= result.status === 'PASS' ? 'success' : 'danger' %>">
+                                                                    <%= result.status === 'PASS' ? 'نجح' : result.status === 'FAIL' ? 'فشل' : result.status %>
+                                                                </span>
                                                             <% } %>
                                                         </td>
                                                         <td>


### PR DESCRIPTION
Update project exam submission to set initial status to 'Under Review' with no marks, and display all uploaded project files on the exam result page.

This PR addresses two issues:
1.  Project exams were automatically marked 0 upon submission. The system now sets the initial status to `UNDER_REVIEW` and updates the UI to display "قيد المراجعة" (Under Review) with no marks until the project is graded.
2.  Only one project file was displayed on the exam result page. The result details page is enhanced to iterate and display all submitted project files with their details and download links, while maintaining backward compatibility for single-file submissions.

---
<a href="https://cursor.com/background-agent?bcId=bc-eaa11a07-99ee-4696-bc03-a51e3343666f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eaa11a07-99ee-4696-bc03-a51e3343666f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

